### PR TITLE
changed the way images and text get laid out together

### DIFF
--- a/ContentBox.java
+++ b/ContentBox.java
@@ -14,4 +14,5 @@ abstract class ContentBox{
   public Rectangle render(Rectangle area, PGraphics pg){
     return render(area, pg, false);
   }
+  public abstract boolean isResizable();
 }

--- a/ContentBoxes.pde
+++ b/ContentBoxes.pde
@@ -4,6 +4,10 @@ class ImageBox extends ContentBox{
     image = img;
   }
   
+  public boolean isResizable(){
+    return true;
+  }
+  
   public Rectangle render(Rectangle area, PGraphics pg, boolean debug){
     if (image == null){
       return new Rectangle(area.x, area.y, 0, 0);
@@ -14,8 +18,9 @@ class ImageBox extends ContentBox{
       float sWidth = image.width * scale;
       float sHeight = image.height * scale;
       image.filter(GRAY);
-      pg.image(image, area.x + area.w - sWidth, area.y, sWidth, sHeight);
-      return new Rectangle(area.x + area.w - sWidth, area.y, sWidth, sHeight);
+      Rectangle destination = new Rectangle(area.x + (area.w - sWidth) / 2, area.y, sWidth, sHeight);
+      pg.image(image, destination.x, destination.y, destination.w, destination.h);
+      return destination;
     }
   }
 }
@@ -37,6 +42,10 @@ class TextBox extends ContentBox{
     font = fnt;
     fontSize = size;
     adjustFontSize = adjustSize;
+  }
+  
+  public boolean isResizable(){
+    return adjustFontSize;
   }
   
   public Rectangle render(Rectangle area, PGraphics pg, boolean debug){
@@ -65,6 +74,9 @@ class HeadingBox extends ContentBox{
     font = _font;
     headingSize = _headingSize;
     subheadingSize = _subheadingSize;
+  }
+  public boolean isResizable(){
+    return false;
   }
   private boolean hasHeading(){
     return heading != null && heading.length() > 0;
@@ -99,7 +111,7 @@ class HeadingBox extends ContentBox{
         pg.rect(area.x, area.y, area.w, area.h);
         pg.popStyle();
       }
-      return area;
+      return new Rectangle(area.x, area.y, block.maxWidth, block.totalHeight);
     } else {
       return new Rectangle(area.x, area.y, 0, 0);
     }

--- a/Rectangle.java
+++ b/Rectangle.java
@@ -7,4 +7,8 @@ public class Rectangle{
     this.w = width;
     this.h = height;
   }
+  
+  public String toString(){
+    return String.format("%1$f,%2$f,%3$f,%4$f",x,y,w,h);
+  }
 }


### PR DESCRIPTION
The included images should give you an idea of the ramifications of this code change. images get centered and show as big as possible given their resolution.

![pg1](https://cloud.githubusercontent.com/assets/1174430/8804132/88436e3a-2f7f-11e5-9f4d-196c196dc7be.jpg)
![pg2](https://cloud.githubusercontent.com/assets/1174430/8804015/f502ec5e-2f7e-11e5-9997-7b5b2c7f734d.jpg)
![pg3](https://cloud.githubusercontent.com/assets/1174430/8804013/f5005f20-2f7e-11e5-80a1-e185f2871c9e.jpg)
![pg4](https://cloud.githubusercontent.com/assets/1174430/8804016/f505ac1e-2f7e-11e5-8a84-c30a777ce339.jpg)
